### PR TITLE
Potential fix for code scanning alert no. 91: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -19,6 +19,9 @@ env:
 
 jobs:
   create-pull-request:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/itsall4mykids21-cmd/next.js/security/code-scanning/91](https://github.com/itsall4mykids21-cmd/next.js/security/code-scanning/91)

To fix the flagged problem, we should add a `permissions` block to the workflow. Since the workflow creates pull requests and commits, it will likely need `contents: write` and `pull-requests: write` permissions, at least within the job that performs those actions. The most secure approach is to add the block under the job definition (`create-pull-request`) rather than globally, unless all jobs need the same permissions. The edit should only introduce the minimum required permissions. Thus, we will add the following block to the `create-pull-request` job, right above `runs-on: ubuntu-latest`:

```yaml
permissions:
  contents: write
  pull-requests: write
```

No additional imports, methods, or code changes are needed, just this insertion into the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
