### PR TITLE
Potential fix for code scanning alert no. 214: Type confusion through parameter tampering

### DIFF
--- a/examples/cms-agilitycms/lib/preview.ts
+++ b/examples/cms-agilitycms/lib/preview.ts
@@ -80,10 +80,10 @@ export async function validateSlugForPreview({ slug, contentID }) {
 //Validates whether the incoming preview request is valid
 export async function validatePreview({ agilityPreviewKey, slug, contentID }) {
   //Validate the preview key
-  if (!agilityPreviewKey) {
+  if (typeof agilityPreviewKey !== "string") {
     return {
       error: true,
-      message: `Missing agilitypreviewkey.`,
+      message: `Missing or invalid agilitypreviewkey.`,
     };
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/itsall4mykids21-cmd/next.js/security/code-scanning/214](https://github.com/itsall4mykids21-cmd/next.js/security/code-scanning/214)

To fix the problem, add a runtime type check to ensure that `agilityPreviewKey` is a string before performing string operations (`includes`, `split`, and comparison). If it is not a string (i.e., it is missing, an array, or any other type), immediately return an error stating that the preview key is missing or malformed. This change should be applied inside the `validatePreview` function in the `examples/cms-agilitycms/lib/preview.ts` file, directly before using string methods on `agilityPreviewKey`. No new imports or large changes are necessary; just guard the logic with a `typeof` (and possibly `Array.isArray`) type check, as appropriate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
